### PR TITLE
Update rest-live-hooks to use the upcoming DRL API

### DIFF
--- a/packages/rest-live-hooks/src/Websocket.tsx
+++ b/packages/rest-live-hooks/src/Websocket.tsx
@@ -64,7 +64,11 @@ class WebsocketManager {
 
   sendSubscriptionFor(listener: UpdateListener) {
     this.websocket!.send(
-      JSON.stringify({ request_id: listener.request_id, ...listener.request })
+      JSON.stringify({
+        type: "subscribe",
+        request_id: listener.request_id,
+        ...listener.request,
+      })
     );
   }
 
@@ -143,7 +147,7 @@ class WebsocketManager {
         "Unsubscribe cannot be called if no connection has been established"
       );
     }
-    this.websocket.send(JSON.stringify({ request_id, unsubscribe: true }));
+    this.websocket.send(JSON.stringify({ type: "unsubscribe", request_id }));
     this.listeners = this.listeners.filter((l) => l.request_id !== request_id);
   }
 }

--- a/packages/rest-live-hooks/src/index.ts
+++ b/packages/rest-live-hooks/src/index.ts
@@ -6,5 +6,5 @@ export {
   useRealtimeResource,
   useRealtimeResourceList,
   WebsocketProvider,
-  WSContext,
+  WSContext
 };

--- a/packages/rest-live-hooks/src/takeTicket.ts
+++ b/packages/rest-live-hooks/src/takeTicket.ts
@@ -1,0 +1,4 @@
+export const takeTicket = (() => {
+  let count = 0;
+  return () => count++;
+})();

--- a/packages/rest-live-hooks/src/types.ts
+++ b/packages/rest-live-hooks/src/types.ts
@@ -10,6 +10,8 @@ export enum Action {
 export interface SubscribeRequest {
   model: string;
   action?: "retrieve" | "list";
+  view_kwargs?: { [key: string]: any };
+  query_params?: { [key: string]: any };
 }
 
 export interface RealtimeRetrieveRequestProps<

--- a/packages/rest-live-hooks/src/types.ts
+++ b/packages/rest-live-hooks/src/types.ts
@@ -4,21 +4,29 @@ import { MutableRefObject } from "react";
 export enum Action {
   CREATED = "CREATED",
   UPDATED = "UPDATED",
-  DELETED = "DELETED",
+  DELETED = "DELETED"
 }
 
-export type SubscribeRequest<
+export interface SubscribeRequest {
+  model: string;
+  action?: "retrieve" | "list";
+}
+
+export interface RealtimeRetrieveRequestProps<
   R extends Identifiable,
   K extends keyof R = keyof R
-> = {
-  model: string;
-  group_by?: K;
-  value: Identifier;
-};
+> extends SubscribeRequest {
+  action?: "retrieve";
+  lookup_by: Identifier;
+}
 
-export type ResourceUpdate<R extends Identifiable> = {
+export interface RealtimeListRequestProps extends SubscribeRequest {
+  action?: "list";
+}
+
+export type ResourceBroadcast<R extends Identifiable> = {
   type: "broadcast";
-  request_id: number;
+  id: number;
   model: string;
   action: Action;
   instance: R;
@@ -29,8 +37,10 @@ export type RevalidationUpdate = {
 };
 export type UpdateListener = {
   request_id: number;
-  request: SubscribeRequest<any>;
+  request: SubscribeRequest;
   notify: MutableRefObject<
-    (update: ResourceUpdate<any> | RevalidationUpdate) => Promise<any[] | any>
+    (
+      update: ResourceBroadcast<any> | RevalidationUpdate
+    ) => Promise<any[] | any>
   >;
 };

--- a/packages/rest-live-hooks/src/types.ts
+++ b/packages/rest-live-hooks/src/types.ts
@@ -1,4 +1,5 @@
-import { Identifiable } from "@pennlabs/rest-hooks";
+import { Identifiable, Identifier } from "@pennlabs/rest-hooks";
+import { MutableRefObject } from "react";
 
 export enum Action {
   CREATED = "CREATED",
@@ -11,17 +12,25 @@ export type SubscribeRequest<
   K extends keyof R = keyof R
 > = {
   model: string;
-  property?: K;
-  value: string | number;
+  group_by?: K;
+  value: Identifier;
 };
 
 export type ResourceUpdate<R extends Identifiable> = {
-  action: Action;
+  type: "broadcast";
+  request_id: number;
   model: string;
+  action: Action;
   instance: R;
-  group_key_value: string | number;
 };
 
 export type RevalidationUpdate = {
   action: "REVALIDATE";
+};
+export type UpdateListener = {
+  request_id: number;
+  request: SubscribeRequest<any>;
+  notify: MutableRefObject<
+    (update: ResourceUpdate<any> | RevalidationUpdate) => Promise<any[] | any>
+  >;
 };

--- a/packages/rest-live-hooks/src/useRealtimeResource.ts
+++ b/packages/rest-live-hooks/src/useRealtimeResource.ts
@@ -59,7 +59,6 @@ function useRealtimeResource<R extends Identifiable>(
   };
   useEffect(() => {
     const request_id = takeTicket();
-    console.log(`DEBUG: Picked ticket with id=${request_id}`);
     websocket.subscribe(subscribeRequest, callbackRef, request_id).then();
     return () => websocket.unsubscribe(request_id);
   }, []);

--- a/packages/rest-live-hooks/src/useRealtimeResource.ts
+++ b/packages/rest-live-hooks/src/useRealtimeResource.ts
@@ -11,7 +11,8 @@ import {
   SubscribeRequest,
   RevalidationUpdate,
 } from "./types";
-import { takeTicket, WSContext } from "./Websocket";
+import { WSContext } from "./Websocket";
+import { takeTicket } from "./takeTicket";
 
 interface useRealtimeResourceResponse<R> extends useResourceResponse<R> {
   isConnected: boolean;
@@ -57,9 +58,10 @@ function useRealtimeResource<R extends Identifiable>(
     }
   };
   useEffect(() => {
-    const uuid = takeTicket();
-    websocket.subscribe(subscribeRequest, callbackRef, uuid).then();
-    return () => websocket.unsubscribe(uuid);
+    const request_id = takeTicket();
+    console.log(`DEBUG: Picked ticket with id=${request_id}`);
+    websocket.subscribe(subscribeRequest, callbackRef, request_id).then();
+    return () => websocket.unsubscribe(request_id);
   }, []);
 
   return { isConnected, ...response };

--- a/packages/rest-live-hooks/src/useRealtimeResource.ts
+++ b/packages/rest-live-hooks/src/useRealtimeResource.ts
@@ -62,7 +62,12 @@ function useRealtimeResource<R extends Identifiable>(
     const request_id = takeTicket();
     websocket
       .subscribe(
-        { action: "retrieve", ...subscribeRequest },
+        {
+          action: "retrieve",
+          view_kwargs: {},
+          query_params: {},
+          ...subscribeRequest
+        },
         callbackRef,
         request_id
       )

--- a/packages/rest-live-hooks/src/useRealtimeResourceList.ts
+++ b/packages/rest-live-hooks/src/useRealtimeResourceList.ts
@@ -77,7 +77,12 @@ function useRealtimeResourceList<R extends Identifiable, K extends keyof R>(
     const request_id = takeTicket();
     websocket
       .subscribe(
-        { action: "list", ...subscribeRequest },
+        {
+          action: "list",
+          view_kwargs: {},
+          query_params: {},
+          ...subscribeRequest
+        },
         callbackRef,
         request_id
       )

--- a/packages/rest-live-hooks/src/useRealtimeResourceList.ts
+++ b/packages/rest-live-hooks/src/useRealtimeResourceList.ts
@@ -12,7 +12,8 @@ import {
   SubscribeRequest,
   RevalidationUpdate,
 } from "./types";
-import { takeTicket, WSContext } from "./Websocket";
+import { WSContext } from "./Websocket";
+import { takeTicket } from "./takeTicket";
 
 interface useRealtimeResourceListResponse<R extends Identifiable>
   extends useResourceListResponse<R> {
@@ -73,9 +74,9 @@ function useRealtimeResourceList<R extends Identifiable, K extends keyof R>(
   };
 
   useEffect(() => {
-    const uuid = takeTicket();
-    websocket.subscribe(subscribeRequest, callbackRef, uuid).then();
-    return () => websocket.unsubscribe(uuid);
+    const request_id = takeTicket();
+    websocket.subscribe(subscribeRequest, callbackRef, request_id).then();
+    return () => websocket.unsubscribe(request_id);
   }, []);
 
   return { isConnected, ...response };

--- a/packages/rest-live-hooks/tests/useRealtimeResource.test.tsx
+++ b/packages/rest-live-hooks/tests/useRealtimeResource.test.tsx
@@ -17,6 +17,7 @@ import { WebsocketProvider, WSContext } from "../src/Websocket";
 
 let ws: WS;
 
+const REQUEST_ID = 1337;
 const WS_HOST = "ws://localhost:3000";
 const MODEL = "todolist.Task";
 interface Elem {
@@ -41,6 +42,10 @@ jest.mock("../src/findOrigin", () => ({
   SITE_ORIGIN: () => WS_HOST,
 }));
 
+jest.mock("../src/takeTicket", () => ({
+  takeTicket: () => REQUEST_ID,
+}));
+
 describe("useRealtimeResource", () => {
   test("should connect to websocket", async () => {
     const Page = () => {
@@ -61,6 +66,7 @@ describe("useRealtimeResource", () => {
     await ws.connected;
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        request_id: REQUEST_ID,
         model: MODEL,
         value: 1,
       })
@@ -95,6 +101,7 @@ describe("useRealtimeResource", () => {
     await ws.connected;
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        request_id: REQUEST_ID,
         model: MODEL,
         value: 1,
       })
@@ -104,8 +111,7 @@ describe("useRealtimeResource", () => {
 
     await expect(ws).toReceiveMessage(
       JSON.stringify({
-        model: MODEL,
-        value: 1,
+        request_id: REQUEST_ID,
         unsubscribe: true,
       })
     );
@@ -132,6 +138,7 @@ describe("useRealtimeResource", () => {
     await ws.connected;
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        request_id: REQUEST_ID,
         model: MODEL,
         value: 1,
       })
@@ -157,13 +164,14 @@ describe("useRealtimeResource", () => {
     );
     await ws.connected; // test will time out if connection fails.
     const update: ResourceUpdate<Elem> = {
+      type: "broadcast",
+      request_id: REQUEST_ID,
       model: MODEL,
       action: Action.UPDATED,
       instance: {
         id: 1,
         message: "hello",
       },
-      group_key_value: 1,
     };
     act(() => {
       ws.send(JSON.stringify(update));
@@ -207,6 +215,7 @@ describe("useRealtimeResource", () => {
     await ws.connected;
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        request_id: REQUEST_ID,
         model: MODEL,
         value: 1,
       })
@@ -221,6 +230,7 @@ describe("useRealtimeResource", () => {
 
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        request_id: REQUEST_ID,
         model: MODEL,
         value: 1,
       })

--- a/packages/rest-live-hooks/tests/useRealtimeResource.test.tsx
+++ b/packages/rest-live-hooks/tests/useRealtimeResource.test.tsx
@@ -11,7 +11,7 @@ import { cache } from "swr";
 // @ts-ignore
 import useRealtimeResource from "../src/useRealtimeResource";
 // @ts-ignore
-import { Action, ResourceUpdate } from "../src/types";
+import { Action, ResourceBroadcast } from "../src/types";
 // @ts-ignore
 import { WebsocketProvider, WSContext } from "../src/Websocket";
 
@@ -51,7 +51,7 @@ describe("useRealtimeResource", () => {
     const Page = () => {
       const { data } = useRealtimeResource(
         "/items/1/",
-        { model: MODEL, value: 1 },
+        { model: MODEL, lookup_by: 1 },
         { fetcher }
       );
       return <div>message: {data && data.message}</div>;
@@ -67,9 +67,10 @@ describe("useRealtimeResource", () => {
     await expect(ws).toReceiveMessage(
       JSON.stringify({
         type: "subscribe",
-        request_id: REQUEST_ID,
+        id: REQUEST_ID,
+        action: "retrieve",
         model: MODEL,
-        value: 1,
+        lookup_by: 1,
       })
     );
     expect(container.firstChild.textContent).toBe("message: hi");
@@ -81,7 +82,7 @@ describe("useRealtimeResource", () => {
         "/items/1/",
         {
           model: MODEL,
-          value: 1,
+          lookup_by: 1,
         },
         { fetcher }
       );
@@ -103,9 +104,10 @@ describe("useRealtimeResource", () => {
     await expect(ws).toReceiveMessage(
       JSON.stringify({
         type: "subscribe",
-        request_id: REQUEST_ID,
+        id: REQUEST_ID,
+        action: "retrieve",
         model: MODEL,
-        value: 1,
+        lookup_by: 1,
       })
     );
 
@@ -114,7 +116,7 @@ describe("useRealtimeResource", () => {
     await expect(ws).toReceiveMessage(
       JSON.stringify({
         type: "unsubscribe",
-        request_id: REQUEST_ID,
+        id: REQUEST_ID,
       })
     );
   });
@@ -125,7 +127,7 @@ describe("useRealtimeResource", () => {
         "/items/1/",
         {
           model: MODEL,
-          value: 1,
+          lookup_by: 1,
         },
         { fetcher }
       );
@@ -141,9 +143,10 @@ describe("useRealtimeResource", () => {
     await expect(ws).toReceiveMessage(
       JSON.stringify({
         type: "subscribe",
-        request_id: REQUEST_ID,
+        id: REQUEST_ID,
+        action: "retrieve",
         model: MODEL,
-        value: 1,
+        lookup_by: 1,
       })
     );
     unmount();
@@ -155,7 +158,7 @@ describe("useRealtimeResource", () => {
     const Page = () => {
       const { data } = useRealtimeResource(
         "/items/2/",
-        { model: MODEL, value: 1 },
+        { model: MODEL, lookup_by: 1 },
         { fetcher }
       );
       return <div>message: {data && data.message}</div>;
@@ -166,9 +169,9 @@ describe("useRealtimeResource", () => {
       </WebsocketProvider>
     );
     await ws.connected; // test will time out if connection fails.
-    const update: ResourceUpdate<Elem> = {
+    const update: ResourceBroadcast<Elem> = {
       type: "broadcast",
-      request_id: REQUEST_ID,
+      id: REQUEST_ID,
       model: MODEL,
       action: Action.UPDATED,
       instance: {
@@ -193,7 +196,7 @@ describe("useRealtimeResource", () => {
       const { isConnected } = useContext(WSContext);
       const { data } = useRealtimeResource(
         "/items/1/",
-        { model: MODEL, value: 1 },
+        { model: MODEL, lookup_by: 1 },
         { fetcher: stateFetcher }
       );
       return (
@@ -219,9 +222,10 @@ describe("useRealtimeResource", () => {
     await expect(ws).toReceiveMessage(
       JSON.stringify({
         type: "subscribe",
-        request_id: REQUEST_ID,
+        id: REQUEST_ID,
+        action: "retrieve",
         model: MODEL,
-        value: 1,
+        lookup_by: 1,
       })
     );
     expect(container.firstChild.firstChild.textContent).toBe("message: hi0");
@@ -235,9 +239,10 @@ describe("useRealtimeResource", () => {
     await expect(ws).toReceiveMessage(
       JSON.stringify({
         type: "subscribe",
-        request_id: REQUEST_ID,
+        id: REQUEST_ID,
+        action: "retrieve",
         model: MODEL,
-        value: 1,
+        lookup_by: 1,
       })
     );
     expect(container.firstChild.firstChild.textContent).toBe("message: hi1");

--- a/packages/rest-live-hooks/tests/useRealtimeResource.test.tsx
+++ b/packages/rest-live-hooks/tests/useRealtimeResource.test.tsx
@@ -66,6 +66,7 @@ describe("useRealtimeResource", () => {
     await ws.connected;
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        type: "subscribe",
         request_id: REQUEST_ID,
         model: MODEL,
         value: 1,
@@ -101,6 +102,7 @@ describe("useRealtimeResource", () => {
     await ws.connected;
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        type: "subscribe",
         request_id: REQUEST_ID,
         model: MODEL,
         value: 1,
@@ -111,8 +113,8 @@ describe("useRealtimeResource", () => {
 
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        type: "unsubscribe",
         request_id: REQUEST_ID,
-        unsubscribe: true,
       })
     );
   });
@@ -138,6 +140,7 @@ describe("useRealtimeResource", () => {
     await ws.connected;
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        type: "subscribe",
         request_id: REQUEST_ID,
         model: MODEL,
         value: 1,
@@ -215,6 +218,7 @@ describe("useRealtimeResource", () => {
     await ws.connected;
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        type: "subscribe",
         request_id: REQUEST_ID,
         model: MODEL,
         value: 1,
@@ -230,6 +234,7 @@ describe("useRealtimeResource", () => {
 
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        type: "subscribe",
         request_id: REQUEST_ID,
         model: MODEL,
         value: 1,

--- a/packages/rest-live-hooks/tests/useRealtimeResource.test.tsx
+++ b/packages/rest-live-hooks/tests/useRealtimeResource.test.tsx
@@ -69,6 +69,8 @@ describe("useRealtimeResource", () => {
         type: "subscribe",
         id: REQUEST_ID,
         action: "retrieve",
+        view_kwargs: {},
+        query_params: {},
         model: MODEL,
         lookup_by: 1,
       })
@@ -106,6 +108,8 @@ describe("useRealtimeResource", () => {
         type: "subscribe",
         id: REQUEST_ID,
         action: "retrieve",
+        view_kwargs: {},
+        query_params: {},
         model: MODEL,
         lookup_by: 1,
       })
@@ -145,6 +149,8 @@ describe("useRealtimeResource", () => {
         type: "subscribe",
         id: REQUEST_ID,
         action: "retrieve",
+        view_kwargs: {},
+        query_params: {},
         model: MODEL,
         lookup_by: 1,
       })
@@ -224,6 +230,8 @@ describe("useRealtimeResource", () => {
         type: "subscribe",
         id: REQUEST_ID,
         action: "retrieve",
+        view_kwargs: {},
+        query_params: {},
         model: MODEL,
         lookup_by: 1,
       })
@@ -241,6 +249,8 @@ describe("useRealtimeResource", () => {
         type: "subscribe",
         id: REQUEST_ID,
         action: "retrieve",
+        view_kwargs: {},
+        query_params: {},
         model: MODEL,
         lookup_by: 1,
       })

--- a/packages/rest-live-hooks/tests/useRealtimeResourceList.test.tsx
+++ b/packages/rest-live-hooks/tests/useRealtimeResourceList.test.tsx
@@ -80,6 +80,8 @@ describe("useRealtimeResourceList", () => {
         type: "subscribe",
         id: REQUEST_ID,
         action: "list",
+        view_kwargs: {},
+        query_params: {},
         model: MODEL,
       } as SubscribeRequest)
     );
@@ -115,6 +117,8 @@ describe("useRealtimeResourceList", () => {
         type: "subscribe",
         id: REQUEST_ID,
         action: "list",
+        view_kwargs: {},
+        query_params: {},
         model: MODEL,
       } as SubscribeRequest)
     );
@@ -152,6 +156,8 @@ describe("useRealtimeResourceList", () => {
         type: "subscribe",
         id: REQUEST_ID,
         action: "list",
+        view_kwargs: {},
+        query_params: {},
         model: MODEL,
       } as SubscribeRequest)
     );
@@ -346,6 +352,8 @@ describe("useRealtimeResourceList", () => {
         type: "subscribe",
         id: REQUEST_ID,
         action: "list",
+        view_kwargs: {},
+        query_params: {},
         model: MODEL,
       } as SubscribeRequest)
     );
@@ -366,11 +374,45 @@ describe("useRealtimeResourceList", () => {
         type: "subscribe",
         id: REQUEST_ID,
         action: "list",
+        view_kwargs: {},
+        query_params: {},
         model: MODEL,
       } as SubscribeRequest)
     );
     expect(container.firstChild.firstChild.textContent).toBe(
       "message: bye earth"
     );
+  });
+
+  test("should pass along view_kwargs and query_params", async () => {
+    const num = 1;
+    const Page = () => {
+      const { data } = useRealtimeResourceList(
+        `/items-${num}/`,
+        (id) => `/items-${num}/${id}/`,
+        { model: MODEL, view_kwargs: { item: 1 }, query_params: { all: true } },
+        { fetcher }
+      );
+      return <div>message: {data && data.map((e) => e.message).join(" ")}</div>;
+    };
+    const { container } = render(
+      <WebsocketProvider url="/api/ws/subscribe/">
+        <Page />
+      </WebsocketProvider>
+    );
+    expect(container.firstChild.textContent).toBe("message: ");
+    await waitForDomChange({ container });
+    await ws.connected;
+    await expect(ws).toReceiveMessage(
+      JSON.stringify({
+        type: "subscribe",
+        id: REQUEST_ID,
+        action: "list",
+        view_kwargs: { item: 1 },
+        query_params: { all: true },
+        model: MODEL,
+      } as SubscribeRequest)
+    );
+    expect(container.firstChild.textContent).toBe("message: hello world");
   });
 });

--- a/packages/rest-live-hooks/tests/useRealtimeResourceList.test.tsx
+++ b/packages/rest-live-hooks/tests/useRealtimeResourceList.test.tsx
@@ -11,7 +11,7 @@ import { cache } from "swr";
 // @ts-ignore
 import useRealtimeResourceList from "../src/useRealtimeResourceList";
 // @ts-ignore
-import { Action, ResourceUpdate, SubscribeRequest } from "../src/types";
+import { Action, ResourceBroadcast, SubscribeRequest } from "../src/types";
 // @ts-ignore
 import { WebsocketProvider, WSContext } from "../src/Websocket";
 
@@ -62,7 +62,7 @@ describe("useRealtimeResourceList", () => {
       const { data } = useRealtimeResourceList(
         `/items-${num}/`,
         (id) => `/items-${num}/${id}/`,
-        { model: MODEL, group_by: "list_id", value: 1 },
+        { model: MODEL },
         { fetcher }
       );
       return <div>message: {data && data.map((e) => e.message).join(" ")}</div>;
@@ -78,11 +78,10 @@ describe("useRealtimeResourceList", () => {
     await expect(ws).toReceiveMessage(
       JSON.stringify({
         type: "subscribe",
-        request_id: REQUEST_ID,
+        id: REQUEST_ID,
+        action: "list",
         model: MODEL,
-        group_by: "list_id",
-        value: 1,
-      } as SubscribeRequest<Elem>)
+      } as SubscribeRequest)
     );
     expect(container.firstChild.textContent).toBe("message: hello world");
   });
@@ -93,7 +92,7 @@ describe("useRealtimeResourceList", () => {
       const { data } = useRealtimeResourceList(
         `/items-${num}/`,
         (id) => `/items-${num}/${id}/`,
-        { model: MODEL, group_by: "list_id", value: 1 },
+        { model: MODEL },
         { fetcher }
       );
       return <div>message: {data && data.map((e) => e.message).join(" ")}</div>;
@@ -114,11 +113,10 @@ describe("useRealtimeResourceList", () => {
     await expect(ws).toReceiveMessage(
       JSON.stringify({
         type: "subscribe",
-        request_id: REQUEST_ID,
+        id: REQUEST_ID,
+        action: "list",
         model: MODEL,
-        group_by: "list_id",
-        value: 1,
-      } as SubscribeRequest<Elem>)
+      } as SubscribeRequest)
     );
 
     fireEvent.click(getByText("Click"));
@@ -126,7 +124,7 @@ describe("useRealtimeResourceList", () => {
     await expect(ws).toReceiveMessage(
       JSON.stringify({
         type: "unsubscribe",
-        request_id: REQUEST_ID,
+        id: REQUEST_ID,
       })
     );
   });
@@ -137,7 +135,7 @@ describe("useRealtimeResourceList", () => {
       const { data } = useRealtimeResourceList(
         `/items-${num}/`,
         (id) => `/items-${num}/${id}/`,
-        { model: MODEL, group_by: "list_id", value: 1 },
+        { model: MODEL },
         { fetcher }
       );
       return <div>message: {data && data.map((e) => e.message).join(" ")}</div>;
@@ -152,11 +150,10 @@ describe("useRealtimeResourceList", () => {
     await expect(ws).toReceiveMessage(
       JSON.stringify({
         type: "subscribe",
-        request_id: REQUEST_ID,
+        id: REQUEST_ID,
+        action: "list",
         model: MODEL,
-        group_by: "list_id",
-        value: 1,
-      } as SubscribeRequest<Elem>)
+      } as SubscribeRequest)
     );
 
     unmount();
@@ -169,7 +166,7 @@ describe("useRealtimeResourceList", () => {
       const { data } = useRealtimeResourceList(
         `/items-${num}/`,
         (id) => `/items-${num}/${id}/`,
-        { model: MODEL, group_by: "list_id", value: 1 },
+        { model: MODEL },
         { fetcher }
       );
       return <div>message: {data && data.map((e) => e.message).join(" ")}</div>;
@@ -180,8 +177,8 @@ describe("useRealtimeResourceList", () => {
       </WebsocketProvider>
     );
     await ws.connected; // test will time out if connection fails.
-    const update: ResourceUpdate<Elem> = {
-      request_id: REQUEST_ID,
+    const update: ResourceBroadcast<Elem> = {
+      id: REQUEST_ID,
       type: "broadcast",
       model: MODEL,
       action: Action.UPDATED,
@@ -203,7 +200,7 @@ describe("useRealtimeResourceList", () => {
       const { data } = useRealtimeResourceList(
         `/items-${num}/`,
         (id) => `/items-${num}/${id}/`,
-        { model: MODEL, group_by: "list_id", value: 1 },
+        { model: MODEL },
         { fetcher }
       );
       return <div>message: {data && data.map((e) => e.message).join(" ")}</div>;
@@ -214,8 +211,8 @@ describe("useRealtimeResourceList", () => {
       </WebsocketProvider>
     );
     await ws.connected; // test will time out if connection fails.
-    const update: ResourceUpdate<Elem> = {
-      request_id: REQUEST_ID,
+    const update: ResourceBroadcast<Elem> = {
+      id: REQUEST_ID,
       type: "broadcast",
       model: MODEL,
       action: Action.DELETED,
@@ -237,7 +234,7 @@ describe("useRealtimeResourceList", () => {
       const { data } = useRealtimeResourceList(
         `/items-${num}/`,
         (id) => `/items-${num}/${id}/`,
-        { model: MODEL, group_by: "list_id", value: 1 },
+        { model: MODEL },
         { fetcher, orderBy: (a, b) => a.id - b.id }
       );
       return <div>message: {data && data.map((e) => e.message).join(" ")}</div>;
@@ -248,8 +245,8 @@ describe("useRealtimeResourceList", () => {
       </WebsocketProvider>
     );
     await ws.connected; // test will time out if connection fails.
-    const update: ResourceUpdate<Elem> = {
-      request_id: REQUEST_ID,
+    const update: ResourceBroadcast<Elem> = {
+      id: REQUEST_ID,
       type: "broadcast",
       model: MODEL,
       action: Action.CREATED,
@@ -265,13 +262,13 @@ describe("useRealtimeResourceList", () => {
     expect(container.firstChild.textContent).toBe("message: hello world third");
   });
 
-  test("should check to make sure the request_id is correct", async () => {
+  test("should check to make sure the id is correct", async () => {
     const num = 5;
     const Page = () => {
       const { data } = useRealtimeResourceList(
         `/items-${num}/`,
         (id) => `/items-${num}/${id}/`,
-        { model: MODEL, group_by: "list_id", value: 1 },
+        { model: MODEL },
         { fetcher, orderBy: (a, b) => a.id - b.id }
       );
       return <div>message: {data && data.map((e) => e.message).join(" ")}</div>;
@@ -282,8 +279,8 @@ describe("useRealtimeResourceList", () => {
       </WebsocketProvider>
     );
     await ws.connected; // test will time out if connection fails.
-    const update: ResourceUpdate<Elem> = {
-      request_id: REQUEST_ID + 21,
+    const update: ResourceBroadcast<Elem> = {
+      id: REQUEST_ID + 21,
       type: "broadcast",
       model: MODEL,
       action: Action.CREATED,
@@ -321,7 +318,7 @@ describe("useRealtimeResourceList", () => {
       const { data } = useRealtimeResourceList(
         `/items-${num}/`,
         (id) => `/items-${num}/${id}/`,
-        { model: MODEL, group_by: "list_id", value: 1 },
+        { model: MODEL },
         { fetcher: stateFetcher }
       );
       return (
@@ -347,11 +344,10 @@ describe("useRealtimeResourceList", () => {
     await expect(ws).toReceiveMessage(
       JSON.stringify({
         type: "subscribe",
-        request_id: REQUEST_ID,
+        id: REQUEST_ID,
+        action: "list",
         model: MODEL,
-        group_by: "list_id",
-        value: 1,
-      } as SubscribeRequest<Elem>)
+      } as SubscribeRequest)
     );
     expect(container.firstChild.firstChild.textContent).toBe(
       "message: hello world"
@@ -368,11 +364,10 @@ describe("useRealtimeResourceList", () => {
     await expect(ws).toReceiveMessage(
       JSON.stringify({
         type: "subscribe",
-        request_id: REQUEST_ID,
+        id: REQUEST_ID,
+        action: "list",
         model: MODEL,
-        group_by: "list_id",
-        value: 1,
-      } as SubscribeRequest<Elem>)
+      } as SubscribeRequest)
     );
     expect(container.firstChild.firstChild.textContent).toBe(
       "message: bye earth"

--- a/packages/rest-live-hooks/tests/useRealtimeResourceList.test.tsx
+++ b/packages/rest-live-hooks/tests/useRealtimeResourceList.test.tsx
@@ -17,6 +17,7 @@ import { WebsocketProvider, WSContext } from "../src/Websocket";
 
 let ws: WS;
 
+const REQUEST_ID = 1337;
 const WS_HOST = "ws://localhost:3000";
 const MODEL = "todolist.Task";
 interface Elem {
@@ -50,6 +51,10 @@ jest.mock("../src/findOrigin", () => ({
   SITE_ORIGIN: () => WS_HOST,
 }));
 
+jest.mock("../src/takeTicket", () => ({
+  takeTicket: () => REQUEST_ID,
+}));
+
 describe("useRealtimeResourceList", () => {
   test("should connect to websocket", async () => {
     const num = 1;
@@ -57,7 +62,7 @@ describe("useRealtimeResourceList", () => {
       const { data } = useRealtimeResourceList(
         `/items-${num}/`,
         (id) => `/items-${num}/${id}/`,
-        { model: MODEL, property: "list_id", value: 1 },
+        { model: MODEL, group_by: "list_id", value: 1 },
         { fetcher }
       );
       return <div>message: {data && data.map((e) => e.message).join(" ")}</div>;
@@ -72,8 +77,9 @@ describe("useRealtimeResourceList", () => {
     await ws.connected;
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        request_id: REQUEST_ID,
         model: MODEL,
-        property: "list_id",
+        group_by: "list_id",
         value: 1,
       } as SubscribeRequest<Elem>)
     );
@@ -86,7 +92,7 @@ describe("useRealtimeResourceList", () => {
       const { data } = useRealtimeResourceList(
         `/items-${num}/`,
         (id) => `/items-${num}/${id}/`,
-        { model: MODEL, property: "list_id", value: 1 },
+        { model: MODEL, group_by: "list_id", value: 1 },
         { fetcher }
       );
       return <div>message: {data && data.map((e) => e.message).join(" ")}</div>;
@@ -106,8 +112,9 @@ describe("useRealtimeResourceList", () => {
     await ws.connected;
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        request_id: REQUEST_ID,
         model: MODEL,
-        property: "list_id",
+        group_by: "list_id",
         value: 1,
       } as SubscribeRequest<Elem>)
     );
@@ -116,9 +123,7 @@ describe("useRealtimeResourceList", () => {
 
     await expect(ws).toReceiveMessage(
       JSON.stringify({
-        model: MODEL,
-        property: "list_id",
-        value: 1,
+        request_id: REQUEST_ID,
         unsubscribe: true,
       })
     );
@@ -130,7 +135,7 @@ describe("useRealtimeResourceList", () => {
       const { data } = useRealtimeResourceList(
         `/items-${num}/`,
         (id) => `/items-${num}/${id}/`,
-        { model: MODEL, property: "list_id", value: 1 },
+        { model: MODEL, group_by: "list_id", value: 1 },
         { fetcher }
       );
       return <div>message: {data && data.map((e) => e.message).join(" ")}</div>;
@@ -144,8 +149,9 @@ describe("useRealtimeResourceList", () => {
     await ws.connected;
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        request_id: REQUEST_ID,
         model: MODEL,
-        property: "list_id",
+        group_by: "list_id",
         value: 1,
       } as SubscribeRequest<Elem>)
     );
@@ -160,7 +166,7 @@ describe("useRealtimeResourceList", () => {
       const { data } = useRealtimeResourceList(
         `/items-${num}/`,
         (id) => `/items-${num}/${id}/`,
-        { model: MODEL, property: "list_id", value: 1 },
+        { model: MODEL, group_by: "list_id", value: 1 },
         { fetcher }
       );
       return <div>message: {data && data.map((e) => e.message).join(" ")}</div>;
@@ -172,6 +178,8 @@ describe("useRealtimeResourceList", () => {
     );
     await ws.connected; // test will time out if connection fails.
     const update: ResourceUpdate<Elem> = {
+      request_id: REQUEST_ID,
+      type: "broadcast",
       model: MODEL,
       action: Action.UPDATED,
       instance: {
@@ -179,7 +187,6 @@ describe("useRealtimeResourceList", () => {
         list_id: 1,
         message: "sup",
       },
-      group_key_value: 1,
     };
     act(() => {
       ws.send(JSON.stringify(update));
@@ -193,7 +200,7 @@ describe("useRealtimeResourceList", () => {
       const { data } = useRealtimeResourceList(
         `/items-${num}/`,
         (id) => `/items-${num}/${id}/`,
-        { model: MODEL, property: "list_id", value: 1 },
+        { model: MODEL, group_by: "list_id", value: 1 },
         { fetcher }
       );
       return <div>message: {data && data.map((e) => e.message).join(" ")}</div>;
@@ -205,6 +212,8 @@ describe("useRealtimeResourceList", () => {
     );
     await ws.connected; // test will time out if connection fails.
     const update: ResourceUpdate<Elem> = {
+      request_id: REQUEST_ID,
+      type: "broadcast",
       model: MODEL,
       action: Action.DELETED,
       instance: {
@@ -212,7 +221,6 @@ describe("useRealtimeResourceList", () => {
         list_id: 1,
         message: "world",
       },
-      group_key_value: 1,
     };
     act(() => {
       ws.send(JSON.stringify(update));
@@ -226,7 +234,7 @@ describe("useRealtimeResourceList", () => {
       const { data } = useRealtimeResourceList(
         `/items-${num}/`,
         (id) => `/items-${num}/${id}/`,
-        { model: MODEL, property: "list_id", value: 1 },
+        { model: MODEL, group_by: "list_id", value: 1 },
         { fetcher, orderBy: (a, b) => a.id - b.id }
       );
       return <div>message: {data && data.map((e) => e.message).join(" ")}</div>;
@@ -238,6 +246,8 @@ describe("useRealtimeResourceList", () => {
     );
     await ws.connected; // test will time out if connection fails.
     const update: ResourceUpdate<Elem> = {
+      request_id: REQUEST_ID,
+      type: "broadcast",
       model: MODEL,
       action: Action.CREATED,
       instance: {
@@ -245,7 +255,6 @@ describe("useRealtimeResourceList", () => {
         list_id: 1,
         message: "third",
       },
-      group_key_value: 1,
     };
     act(() => {
       ws.send(JSON.stringify(update));
@@ -253,13 +262,13 @@ describe("useRealtimeResourceList", () => {
     expect(container.firstChild.textContent).toBe("message: hello world third");
   });
 
-  test("should check to make sure the group key is correct", async () => {
+  test("should check to make sure the request_id is correct", async () => {
     const num = 5;
     const Page = () => {
       const { data } = useRealtimeResourceList(
         `/items-${num}/`,
         (id) => `/items-${num}/${id}/`,
-        { model: MODEL, property: "list_id", value: 1 },
+        { model: MODEL, group_by: "list_id", value: 1 },
         { fetcher, orderBy: (a, b) => a.id - b.id }
       );
       return <div>message: {data && data.map((e) => e.message).join(" ")}</div>;
@@ -271,6 +280,8 @@ describe("useRealtimeResourceList", () => {
     );
     await ws.connected; // test will time out if connection fails.
     const update: ResourceUpdate<Elem> = {
+      request_id: REQUEST_ID + 21,
+      type: "broadcast",
       model: MODEL,
       action: Action.CREATED,
       instance: {
@@ -278,7 +289,6 @@ describe("useRealtimeResourceList", () => {
         list_id: 2,
         message: "BLAH",
       },
-      group_key_value: 2,
     };
     act(() => {
       ws.send(JSON.stringify(update));
@@ -308,7 +318,7 @@ describe("useRealtimeResourceList", () => {
       const { data } = useRealtimeResourceList(
         `/items-${num}/`,
         (id) => `/items-${num}/${id}/`,
-        { model: MODEL, property: "list_id", value: 1 },
+        { model: MODEL, group_by: "list_id", value: 1 },
         { fetcher: stateFetcher }
       );
       return (
@@ -333,8 +343,9 @@ describe("useRealtimeResourceList", () => {
     await ws.connected;
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        request_id: REQUEST_ID,
         model: MODEL,
-        property: "list_id",
+        group_by: "list_id",
         value: 1,
       } as SubscribeRequest<Elem>)
     );
@@ -352,8 +363,9 @@ describe("useRealtimeResourceList", () => {
 
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        request_id: REQUEST_ID,
         model: MODEL,
-        property: "list_id",
+        group_by: "list_id",
         value: 1,
       } as SubscribeRequest<Elem>)
     );

--- a/packages/rest-live-hooks/tests/useRealtimeResourceList.test.tsx
+++ b/packages/rest-live-hooks/tests/useRealtimeResourceList.test.tsx
@@ -77,6 +77,7 @@ describe("useRealtimeResourceList", () => {
     await ws.connected;
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        type: "subscribe",
         request_id: REQUEST_ID,
         model: MODEL,
         group_by: "list_id",
@@ -112,6 +113,7 @@ describe("useRealtimeResourceList", () => {
     await ws.connected;
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        type: "subscribe",
         request_id: REQUEST_ID,
         model: MODEL,
         group_by: "list_id",
@@ -123,8 +125,8 @@ describe("useRealtimeResourceList", () => {
 
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        type: "unsubscribe",
         request_id: REQUEST_ID,
-        unsubscribe: true,
       })
     );
   });
@@ -149,6 +151,7 @@ describe("useRealtimeResourceList", () => {
     await ws.connected;
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        type: "subscribe",
         request_id: REQUEST_ID,
         model: MODEL,
         group_by: "list_id",
@@ -343,6 +346,7 @@ describe("useRealtimeResourceList", () => {
     await ws.connected;
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        type: "subscribe",
         request_id: REQUEST_ID,
         model: MODEL,
         group_by: "list_id",
@@ -363,6 +367,7 @@ describe("useRealtimeResourceList", () => {
 
     await expect(ws).toReceiveMessage(
       JSON.stringify({
+        type: "subscribe",
         request_id: REQUEST_ID,
         model: MODEL,
         group_by: "list_id",


### PR DESCRIPTION
[ch2953]
We should hold off on merging this until after https://github.com/pennlabs/django-rest-live/pull/7 gets merged in -- it's possible the API will keep changing.