### PR TITLE
Rest-hooks error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 tsconfig.tsbuildinfo
 yarn-error.log
 coverage/
+**/.vscode

--- a/packages/rest-hooks/src/types.ts
+++ b/packages/rest-hooks/src/types.ts
@@ -10,8 +10,14 @@ export type Response<T, E> =
 
 export type requestOptions = {
   method: string;
+  sendRequest?: boolean;
   revalidate?: boolean;
 }
+
+export type requestFunction<T, E> = (
+  options: requestOptions,
+  requestContent?: Partial<T>,
+) => Promise<Response<T, E>>;
 
 export type mutateResourceOptions = {
   method?: string;
@@ -19,6 +25,7 @@ export type mutateResourceOptions = {
   revalidate?: boolean;
 };
 
+// TODO: should this extend requestFunction?
 export type mutateResourceFunction<T> = (
   patchedResource?: Partial<T>,
   options?: mutateResourceOptions
@@ -43,6 +50,7 @@ export type useResourceResponse<T> = {
   error: any;
   isValidating: boolean;
   mutate: mutateResourceFunction<T>;
+  request: requestFunction<T>
 };
 
 export type useResourceListResponse<T extends Identifiable> = {

--- a/packages/rest-hooks/src/types.ts
+++ b/packages/rest-hooks/src/types.ts
@@ -1,19 +1,18 @@
 export type Identifier = string | number;
 
-export type ListMutateMethod = 
-| "PATCH" | "POST" | "DELETE"
+export type ListMutateMethod = "PATCH" | "POST" | "DELETE";
 
 export interface Identifiable {
   id: Identifier;
 }
 
-export type MutateResponse<T, E> = 
-| { success: true, data: T }
-| { success: false, error: E }
+export type MutateResponse<T, E> =
+  | { success: true; data: T }
+  | { success: false; error: E };
 
 /**
  * Options for a useResource mutate function
- * 
+ *
  * @property {boolean=true} sendRequest  - Whether or not to send the request
  * @property {boolean=true} optimistic   - Enables locally changing the data before revalidating
  * @property {boolean=true} revalidate   - Should we revalidate our data after updating?
@@ -22,11 +21,11 @@ export type mutateOptions = {
   sendRequest?: boolean;
   optimistic?: boolean;
   revalidate?: boolean;
-}
+};
 
 export type mutateFunction<T, E> = (
   requestContent?: Partial<T>,
-  options?: mutateOptions,
+  options?: mutateOptions
 ) => Promise<MutateResponse<T, E>>;
 
 interface mutateListOptionsBase<T> {
@@ -45,25 +44,26 @@ interface mutateListOptionsIdUrl {
   id: Identifier;
 }
 
-type mutateListOptionsMethod = mutateListOptionsBaseUrl | mutateListOptionsIdUrl
+type mutateListOptionsMethod =
+  | mutateListOptionsBaseUrl
+  | mutateListOptionsIdUrl;
 
 /**
  * Options for a useResourceList mutate function
- * 
+ *
  * @property {boolean=true} sendRequest    - Whether or not to send an API request
  * @property {boolean=true} optimistic     - Should we update local data before reverifying?
  * @property {boolean=true} revalidate     - Revalidate after (possibly) updating local data
  * @property {{@link ListMutateMethod}}    - Request method
  * @property {{@link Identifier}} id       - ID of the data to PATCH or DELETE
  */
-export type mutateListOptions<T> =
-  mutateListOptionsBase<T> & mutateListOptionsMethod;
+export type mutateListOptions<T> = mutateListOptionsBase<T> &
+  mutateListOptionsMethod;
 
 export type mutateListFunction<T extends Identifiable, E> = (
   requestContent?: Partial<T> | null,
-  options?: mutateListOptions<T>,
+  options?: mutateListOptions<T>
 ) => Promise<MutateResponse<T[], E>>;
-
 
 // responses
 

--- a/packages/rest-hooks/src/types.ts
+++ b/packages/rest-hooks/src/types.ts
@@ -8,6 +8,13 @@ export type MutateResponse<T, E> =
 | { success: true, data: T }
 | { success: false, error: E }
 
+/**
+ * Options for a useResource mutate function
+ * 
+ * @property {boolean=true} sendRequest  - Whether or not to send the request
+ * @property {boolean=true} optimistic   - Enables locally changing the data before revalidating
+ * @property {boolean=true} revalidate   - Should we revalidate our data after updating?
+ */
 export type mutateOptions = {
   sendRequest?: boolean;
   optimistic?: boolean;

--- a/packages/rest-hooks/src/types.ts
+++ b/packages/rest-hooks/src/types.ts
@@ -25,8 +25,8 @@ export type mutateOptions = {
 }
 
 export type mutateFunction<T, E> = (
-  options: mutateOptions,
   requestContent?: Partial<T>,
+  options?: mutateOptions,
 ) => Promise<MutateResponse<T, E>>;
 
 interface mutateListOptionsBase<T> {
@@ -45,6 +45,8 @@ interface mutateListOptionsIdUrl {
   id: Identifier;
 }
 
+type mutateListOptionsMethod = mutateListOptionsBaseUrl | mutateListOptionsIdUrl
+
 /**
  * Options for a useResourceList mutate function
  * 
@@ -55,11 +57,11 @@ interface mutateListOptionsIdUrl {
  * @property {{@link Identifier}} id       - ID of the data to PATCH or DELETE
  */
 export type mutateListOptions<T> =
-  mutateListOptionsBase<T> & (mutateListOptionsBaseUrl | mutateListOptionsIdUrl);
+  mutateListOptionsBase<T> & mutateListOptionsMethod;
 
 export type mutateListFunction<T extends Identifiable, E> = (
-  options: mutateListOptions<T>,
   requestContent?: Partial<T> | null,
+  options?: mutateListOptions<T>,
 ) => Promise<MutateResponse<T[], E>>;
 
 

--- a/packages/rest-hooks/src/types.ts
+++ b/packages/rest-hooks/src/types.ts
@@ -4,32 +4,20 @@ export interface Identifiable {
   id: Identifier;
 }
 
-export type Response<T, E> = 
+export type MutateResponse<T, E> = 
 | { success: true, data: T }
-| { success: false, err: E }
+| { success: false, error: E }
 
-export type requestOptions = {
-  method: string;
+export type mutateOptions = {
   sendRequest?: boolean;
+  optimistic?: boolean;
   revalidate?: boolean;
 }
 
-export type requestFunction<T, E> = (
-  options: requestOptions,
+export type mutateFunction<T, E> = (
+  options: mutateOptions,
   requestContent?: Partial<T>,
-) => Promise<Response<T, E>>;
-
-export type mutateResourceOptions = {
-  method?: string;
-  sendRequest?: boolean;
-  revalidate?: boolean;
-};
-
-// TODO: should this extend requestFunction?
-export type mutateResourceFunction<T> = (
-  patchedResource?: Partial<T>,
-  options?: mutateResourceOptions
-) => Promise<T | undefined>;
+) => Promise<MutateResponse<T, E>>;
 
 export type mutateResourceListOptions<T> = {
   method?: string;
@@ -45,12 +33,11 @@ export type mutateResourceListFunction<T extends Identifiable> = (
   options?: mutateResourceListOptions<T>
 ) => Promise<T[] | undefined>;
 
-export type useResourceResponse<T> = {
-  data: T | undefined;
-  error: any;
+export type useResourceResponse<T, E> = {
+  data?: T;
+  error?: E;
   isValidating: boolean;
-  mutate: mutateResourceFunction<T>;
-  request: requestFunction<T>
+  mutate: mutateFunction<T, E>;
 };
 
 export type useResourceListResponse<T extends Identifiable> = {

--- a/packages/rest-hooks/src/types.ts
+++ b/packages/rest-hooks/src/types.ts
@@ -4,6 +4,15 @@ export interface Identifiable {
   id: Identifier;
 }
 
+export type Response<T, E> = 
+| { success: true, data: T }
+| { success: false, err: E }
+
+export type requestOptions = {
+  method: string;
+  revalidate?: boolean;
+}
+
 export type mutateResourceOptions = {
   method?: string;
   sendRequest?: boolean;

--- a/packages/rest-hooks/src/useResource.ts
+++ b/packages/rest-hooks/src/useResource.ts
@@ -2,6 +2,7 @@ import useSWR, { ConfigInterface } from "swr";
 import { requestOptions, mutateResourceOptions, useResourceResponse } from "./types";
 import { doApiRequest } from "./fetching";
 
+// TODO: i don't want to add another generic type in here for errors.. where does it come from...?
 function useResource<R>(
   url: string,
   config?: ConfigInterface<R>
@@ -13,10 +14,27 @@ function useResource<R>(
   });
 
   // any type of request
-  const request = async (
-    options: requestOptions
+  const request = async<R, E> (
+    options: requestOptions,
+    requestContent?: Partial<R>,
+    // TODO: schema?
   ) => {
-    // TODO
+    // TODO: should we be using PATCH?
+    const { method = "PATCH", sendRequest = true, revalidate = true } = options;
+
+    if (requestContent && data) {
+      mutate({ ...data, ...requestContent }, false);
+    }
+    if (sendRequest) {
+      await doApiRequest(url, {
+        method,
+        body: requestContent,
+      });
+    }
+
+    // TODO: make this more flexible... mabye make user provide some type info??
+    if (revalidate) return mutate();
+    else return new Promise<R>(() => {});
   }
 
   // generic mutate function
@@ -40,7 +58,7 @@ function useResource<R>(
     else return new Promise<R>(() => {});
   };
 
-  return { data, error, isValidating, mutate: mutateWithAPI };
+  return { data, error, isValidating, mutate: mutateWithAPI, request };
 }
 
 export default useResource;

--- a/packages/rest-hooks/src/useResource.ts
+++ b/packages/rest-hooks/src/useResource.ts
@@ -2,25 +2,24 @@ import useSWR, { ConfigInterface } from "swr";
 import { mutateFunction, mutateOptions, useResourceResponse } from "./types";
 import { doApiRequest } from "./fetching";
 
-function useResource<T, E> (
+function useResource<T, E>(
   url: string,
   config?: ConfigInterface<T>
 ): useResourceResponse<T, E> {
-
   // call SWR
   const { data, error, isValidating, mutate } = useSWR(url, {
     ...config,
   });
 
   // for patch requests
-  const mutateWithAPI : mutateFunction<T, E> = async (
+  const mutateWithAPI: mutateFunction<T, E> = async (
     newData?: Partial<T>,
-    options: mutateOptions = {},
+    options: mutateOptions = {}
   ) => {
     const {
       sendRequest = true,
       optimistic = true,
-      revalidate = true
+      revalidate = true,
     } = options;
 
     // local stuff we'll send back if not reverifying
@@ -28,7 +27,7 @@ function useResource<T, E> (
 
     // mutate data locally (don't revalidate yet)
     if (optimistic && newData && data) {
-      updatedLocalData = {...data, ...newData};
+      updatedLocalData = { ...data, ...newData };
       mutate(updatedLocalData, false);
     }
 
@@ -40,14 +39,13 @@ function useResource<T, E> (
         });
       }
 
-      if (revalidate) return {success: true, data: await mutate()};
-      
-      return {success: true, data: updatedLocalData}
+      if (revalidate) return { success: true, data: await mutate() };
 
+      return { success: true, data: updatedLocalData };
     } catch (e) {
-      return {success: false, error: e as E}
+      return { success: false, error: e as E };
     }
-  }
+  };
 
   return { data, error, isValidating, mutate: mutateWithAPI };
 }

--- a/packages/rest-hooks/src/useResource.ts
+++ b/packages/rest-hooks/src/useResource.ts
@@ -2,7 +2,7 @@ import useSWR, { ConfigInterface } from "swr";
 import { mutateFunction, mutateOptions, useResourceResponse } from "./types";
 import { doApiRequest } from "./fetching";
 
-function useResource<T, E>(
+function useResource<T, E> (
   url: string,
   config?: ConfigInterface<T>
 ): useResourceResponse<T, E> {
@@ -14,8 +14,8 @@ function useResource<T, E>(
 
   // for patch requests
   const mutateWithAPI : mutateFunction<T, E> = async (
-    options: mutateOptions,
     newData?: Partial<T>,
+    options: mutateOptions = {},
   ) => {
     const {
       sendRequest = true,

--- a/packages/rest-hooks/src/useResource.ts
+++ b/packages/rest-hooks/src/useResource.ts
@@ -1,14 +1,25 @@
 import useSWR, { ConfigInterface } from "swr";
-import { mutateResourceOptions, useResourceResponse } from "./types";
+import { requestOptions, mutateResourceOptions, useResourceResponse } from "./types";
 import { doApiRequest } from "./fetching";
 
 function useResource<R>(
   url: string,
   config?: ConfigInterface<R>
 ): useResourceResponse<R> {
+
+  // call SWR
   const { data, error, isValidating, mutate } = useSWR(url, {
     ...config,
   });
+
+  // any type of request
+  const request = async (
+    options: requestOptions
+  ) => {
+    // TODO
+  }
+
+  // generic mutate function
   const mutateWithAPI = async (
     patchedResource?: Partial<R>,
     options: mutateResourceOptions = {}
@@ -28,6 +39,7 @@ function useResource<R>(
     if (revalidate) return mutate();
     else return new Promise<R>(() => {});
   };
+
   return { data, error, isValidating, mutate: mutateWithAPI };
 }
 

--- a/packages/rest-hooks/src/useResourceList.ts
+++ b/packages/rest-hooks/src/useResourceList.ts
@@ -18,8 +18,8 @@ function useResourceList<T extends Identifiable, E>(
 
   // mutate function (for patch + post requests)
   const mutateWithAPI: mutateListFunction<T, E> = async (
-    options: mutateListOptions<T>,
     requestContent?: Partial<T>,
+    options: mutateListOptions<T> = {} as mutateListOptions<T>,
   ) => {
 
     const {

--- a/packages/rest-hooks/src/useResourceList.ts
+++ b/packages/rest-hooks/src/useResourceList.ts
@@ -60,7 +60,7 @@ function useResourceList<T extends Identifiable, E>(
         const apiPath = (method === "POST")
           // TODO: make sure this actually works
           ? (listUrl instanceof Function ? listUrl() : listUrl)
-          : getResourceUrl(id);
+          : getResourceUrl(options.id);
         await doApiRequest(apiPath, {
           method,
           body: requestContent,

--- a/packages/rest-hooks/src/useResourceList.ts
+++ b/packages/rest-hooks/src/useResourceList.ts
@@ -19,9 +19,8 @@ function useResourceList<T extends Identifiable, E>(
   // mutate function (for patch + post requests)
   const mutateWithAPI: mutateListFunction<T, E> = async (
     requestContent?: Partial<T>,
-    options: mutateListOptions<T> = {} as mutateListOptions<T>,
+    options: mutateListOptions<T> = {} as mutateListOptions<T>
   ) => {
-
     const {
       method,
       sendRequest = true,
@@ -49,7 +48,11 @@ function useResourceList<T extends Identifiable, E>(
       } else {
         // normal PATCH request
         let patchedList: T[];
-        [patchedList, didPatch = false] = patchInList(data, options.id, requestContent);
+        [patchedList, didPatch = false] = patchInList(
+          data,
+          options.id,
+          requestContent
+        );
         if (didPatch) {
           localList = patchedList.sort(sortBy);
         }
@@ -63,25 +66,26 @@ function useResourceList<T extends Identifiable, E>(
       // Only perform an API request when the patch finds a matching entry.
       // need to update this so POST requests use original resource path
       if (sendRequest && didPatch) {
-        const apiPath = (options.method === "POST")
-          // TODO: make sure this actually works
-          ? (listUrl instanceof Function ? listUrl() : listUrl)
-          : getResourceUrl(options.id);
+        const apiPath =
+          options.method === "POST"
+            ? // TODO: make sure this actually works
+              listUrl instanceof Function
+              ? listUrl()
+              : listUrl
+            : getResourceUrl(options.id);
         await doApiRequest(apiPath, {
           method,
           body: requestContent,
         });
       }
 
-      if (revalidate) return {success: true, data: await mutate()};
-
-      else return {success: true, data: localList}
+      if (revalidate) return { success: true, data: await mutate() };
+      else return { success: true, data: localList };
     } catch (e) {
       // on some error, return our non-success pattern
-      return {success: false, error: e as E}
+      return { success: false, error: e as E };
     }
   };
-
 
   return { data, error, isValidating, mutate: mutateWithAPI };
 }

--- a/packages/rest-hooks/src/useResourceList.ts
+++ b/packages/rest-hooks/src/useResourceList.ts
@@ -36,12 +36,18 @@ function useResourceList<T extends Identifiable, E>(
 
     // if ID is undefined/null, don't patch. this is just local mutation.
     if (data && optimistic) {
-      if (method === "POST") {
+      if (options.method === "POST") {
+        // we add our data and sort if it's a POST
         localList = [requestContent as T, ...data].sort(sortBy);
-      } else if (method === "DELETE") {
+      } else if (options.method === "DELETE") {
+        // delete our data from list if DELETE
         let patchedList: T[];
         [patchedList, didPatch = false] = patchInList(data, options.id, null);
+        if (didPatch) {
+          localList = patchedList.sort(sortBy);
+        }
       } else {
+        // normal PATCH request
         let patchedList: T[];
         [patchedList, didPatch = false] = patchInList(data, options.id, requestContent);
         if (didPatch) {
@@ -57,7 +63,7 @@ function useResourceList<T extends Identifiable, E>(
       // Only perform an API request when the patch finds a matching entry.
       // need to update this so POST requests use original resource path
       if (sendRequest && didPatch) {
-        const apiPath = (method === "POST")
+        const apiPath = (options.method === "POST")
           // TODO: make sure this actually works
           ? (listUrl instanceof Function ? listUrl() : listUrl)
           : getResourceUrl(options.id);

--- a/packages/rest-hooks/tests/useResourceList.test.tsx
+++ b/packages/rest-hooks/tests/useResourceList.test.tsx
@@ -121,8 +121,8 @@ describe("useResourceList", () => {
         <div
           onClick={() =>
             mutate(
-              { id: 3, message: "Why," },
-              { sendRequest: false, revalidate: false, method: "PATCH", id: 3 }
+              { id: 0, message: "Why," },
+              { sendRequest: false, revalidate: false, method: "POST" }
             )
           }
         >
@@ -157,8 +157,7 @@ describe("useResourceList", () => {
               {
                 sendRequest: false,
                 revalidate: false,
-                method: "PATCH",
-                id: 3,
+                method: "POST",
                 sortBy: (a, b) => a.id - b.id,
               }
             )

--- a/packages/rest-hooks/tests/useResourceList.test.tsx
+++ b/packages/rest-hooks/tests/useResourceList.test.tsx
@@ -59,7 +59,7 @@ describe("useResourceList", () => {
       );
       return (
         <div
-          onClick={() => mutate(1, { message: "HELLO" }, { revalidate: false })}
+          onClick={() => mutate({ message: "HELLO" }, { revalidate: false, id: 1, method: "PATCH" })}
         >
           message: {data && data.map((e) => e.message).join(" ")}
         </div>
@@ -86,7 +86,7 @@ describe("useResourceList", () => {
       return (
         <div
           onClick={() =>
-            mutate(2, null, { method: "DELETE", revalidate: false })
+            mutate(null, { method: "DELETE", revalidate: false, id: 2 })
           }
         >
           message: {data && data.map((e) => e.message).join(" ")}
@@ -121,9 +121,8 @@ describe("useResourceList", () => {
         <div
           onClick={() =>
             mutate(
-              3,
               { id: 3, message: "Why," },
-              { sendRequest: false, revalidate: false, append: true }
+              { sendRequest: false, revalidate: false, method: "PATCH", id: 3 }
             )
           }
         >
@@ -154,12 +153,12 @@ describe("useResourceList", () => {
         <div
           onClick={() =>
             mutate(
-              3,
               { id: 3, message: "third" },
               {
                 sendRequest: false,
                 revalidate: false,
-                append: true,
+                method: "PATCH",
+                id: 3,
                 sortBy: (a, b) => a.id - b.id,
               }
             )
@@ -217,9 +216,8 @@ describe("useResourceList", () => {
         <div
           onClick={() =>
             mutate(
-              1,
               { id: 1, message: "Yo" },
-              { sendRequest: false, revalidate: false, append: true }
+              { sendRequest: false, revalidate: false, method: "PATCH", id: 1 }
             )
           }
         >

--- a/packages/rest-live-hooks/src/Websocket.tsx
+++ b/packages/rest-live-hooks/src/Websocket.tsx
@@ -15,6 +15,7 @@ import {
 } from "./types";
 import { Identifiable } from "@pennlabs/rest-hooks";
 import { SITE_ORIGIN } from "./findOrigin";
+import { MutateResponse } from "@pennlabs/rest-hooks/dist/types";
 
 export type WSContextProps = {
   websocket: WebsocketManager;
@@ -123,10 +124,10 @@ class WebsocketManager {
     this.websocket?.close();
   }
 
-  async subscribe<T extends Identifiable>(
+  async subscribe<T extends Identifiable, E extends any = any>(
     request: Required<SubscribeRequest>,
     notify: MutableRefObject<
-      (update: ResourceBroadcast<T> | RevalidationUpdate) => Promise<T[] | T>
+      (update: ResourceBroadcast<T> | RevalidationUpdate) => Promise<MutateResponse<T | T[], E>>
     >,
     request_id: number
   ) {

--- a/packages/rest-live-hooks/src/index.ts
+++ b/packages/rest-live-hooks/src/index.ts
@@ -6,5 +6,5 @@ export {
   useRealtimeResource,
   useRealtimeResourceList,
   WebsocketProvider,
-  WSContext
+  WSContext,
 };

--- a/packages/rest-live-hooks/src/types.ts
+++ b/packages/rest-live-hooks/src/types.ts
@@ -4,7 +4,7 @@ import { MutableRefObject } from "react";
 export enum Action {
   CREATED = "CREATED",
   UPDATED = "UPDATED",
-  DELETED = "DELETED"
+  DELETED = "DELETED",
 }
 
 export interface SubscribeRequest {

--- a/packages/rest-live-hooks/src/useRealtimeResource.ts
+++ b/packages/rest-live-hooks/src/useRealtimeResource.ts
@@ -14,12 +14,13 @@ import {
 } from "./types";
 import { WSContext } from "./Websocket";
 import { takeTicket } from "./takeTicket";
+import { MutateResponse } from "@pennlabs/rest-hooks/dist/types";
 
-interface useRealtimeResourceResponse<R> extends useResourceResponse<R> {
+interface useRealtimeResourceResponse<R, E extends any = any> extends useResourceResponse<R, E> {
   isConnected: boolean;
 }
 
-function useRealtimeResource<R extends Identifiable>(
+function useRealtimeResource<R extends Identifiable, E extends any = any>(
   url: string,
   subscribeRequest: RealtimeRetrieveRequestProps<R>,
   config?: ConfigInterface<R>
@@ -37,7 +38,7 @@ function useRealtimeResource<R extends Identifiable>(
   const response = useResource(url, config);
   const { mutate } = response;
   const callbackRef = useRef<
-    (update: ResourceBroadcast<R> | RevalidationUpdate) => Promise<R>
+    (update: ResourceBroadcast<R> | RevalidationUpdate) => Promise<MutateResponse<R, E>>
   >();
 
   callbackRef.current = async (

--- a/packages/rest-live-hooks/src/useRealtimeResource.ts
+++ b/packages/rest-live-hooks/src/useRealtimeResource.ts
@@ -2,7 +2,7 @@ import {
   Identifiable,
   Identifier,
   useResource,
-  useResourceResponse
+  useResourceResponse,
 } from "@pennlabs/rest-hooks";
 import { ConfigInterface } from "swr";
 import { useEffect, useRef, useContext } from "react";
@@ -10,13 +10,14 @@ import {
   Action,
   ResourceBroadcast,
   RevalidationUpdate,
-  RealtimeRetrieveRequestProps
+  RealtimeRetrieveRequestProps,
 } from "./types";
 import { WSContext } from "./Websocket";
 import { takeTicket } from "./takeTicket";
 import { MutateResponse } from "@pennlabs/rest-hooks/dist/types";
 
-interface useRealtimeResourceResponse<R, E extends any = any> extends useResourceResponse<R, E> {
+interface useRealtimeResourceResponse<R, E extends any = any>
+  extends useResourceResponse<R, E> {
   isConnected: boolean;
 }
 
@@ -38,7 +39,9 @@ function useRealtimeResource<R extends Identifiable, E extends any = any>(
   const response = useResource(url, config);
   const { mutate } = response;
   const callbackRef = useRef<
-    (update: ResourceBroadcast<R> | RevalidationUpdate) => Promise<MutateResponse<R, E>>
+    (
+      update: ResourceBroadcast<R> | RevalidationUpdate
+    ) => Promise<MutateResponse<R, E>>
   >();
 
   callbackRef.current = async (
@@ -67,7 +70,7 @@ function useRealtimeResource<R extends Identifiable, E extends any = any>(
           action: "retrieve",
           view_kwargs: {},
           query_params: {},
-          ...subscribeRequest
+          ...subscribeRequest,
         },
         callbackRef,
         request_id

--- a/packages/rest-live-hooks/src/useRealtimeResourceList.ts
+++ b/packages/rest-live-hooks/src/useRealtimeResourceList.ts
@@ -2,7 +2,7 @@ import {
   Identifiable,
   Identifier,
   useResourceList,
-  useResourceListResponse
+  useResourceListResponse,
 } from "@pennlabs/rest-hooks";
 import { ConfigInterface } from "swr";
 import { useEffect, useRef, useContext } from "react";
@@ -10,7 +10,7 @@ import {
   Action,
   ResourceBroadcast,
   RealtimeListRequestProps,
-  RevalidationUpdate
+  RevalidationUpdate,
 } from "./types";
 import { WSContext } from "./Websocket";
 import { takeTicket } from "./takeTicket";
@@ -21,7 +21,11 @@ interface useRealtimeResourceListResponse<R extends Identifiable, E>
   isConnected: boolean;
 }
 
-function useRealtimeResourceList<R extends Identifiable, K extends keyof R, E extends Object>(
+function useRealtimeResourceList<
+  R extends Identifiable,
+  K extends keyof R,
+  E extends Object
+>(
   listUrl: string | (() => string),
   getResourceUrl: (id: Identifier) => string,
   subscribeRequest: RealtimeListRequestProps,
@@ -45,7 +49,9 @@ function useRealtimeResourceList<R extends Identifiable, K extends keyof R, E ex
   const response = useResourceList<R, E>(listUrl, getResourceUrl, config);
   const { mutate } = response;
   const callbackRef = useRef<
-    (update: ResourceBroadcast<R> | RevalidationUpdate) => Promise<MutateResponse<R[], E>>
+    (
+      update: ResourceBroadcast<R> | RevalidationUpdate
+    ) => Promise<MutateResponse<R[], E>>
   >();
 
   callbackRef.current = async (
@@ -57,14 +63,14 @@ function useRealtimeResourceList<R extends Identifiable, K extends keyof R, E ex
           method: "POST",
           sendRequest: false,
           revalidate: false,
-          sortBy: orderBy
-        })
+          sortBy: orderBy,
+        });
       case Action.UPDATED:
         return mutate(update.instance, {
           method: "PATCH",
           id: update.instance.id,
           sendRequest: false,
-          revalidate: false
+          revalidate: false,
         });
       case Action.DELETED:
         return mutate(null, {
@@ -87,7 +93,7 @@ function useRealtimeResourceList<R extends Identifiable, K extends keyof R, E ex
           action: "list",
           view_kwargs: {},
           query_params: {},
-          ...subscribeRequest
+          ...subscribeRequest,
         },
         callbackRef,
         request_id

--- a/packages/rest-live-hooks/src/useRealtimeResourceList.ts
+++ b/packages/rest-live-hooks/src/useRealtimeResourceList.ts
@@ -14,18 +14,19 @@ import {
 } from "./types";
 import { WSContext } from "./Websocket";
 import { takeTicket } from "./takeTicket";
+import { MutateResponse } from "@pennlabs/rest-hooks/dist/types";
 
-interface useRealtimeResourceListResponse<R extends Identifiable>
-  extends useResourceListResponse<R> {
+interface useRealtimeResourceListResponse<R extends Identifiable, E>
+  extends useResourceListResponse<R, E> {
   isConnected: boolean;
 }
 
-function useRealtimeResourceList<R extends Identifiable, K extends keyof R>(
+function useRealtimeResourceList<R extends Identifiable, K extends keyof R, E extends Object>(
   listUrl: string | (() => string),
   getResourceUrl: (id: Identifier) => string,
   subscribeRequest: RealtimeListRequestProps,
   config?: ConfigInterface<R[]> & { orderBy?: (a: R, b: R) => number }
-): useRealtimeResourceListResponse<R> {
+): useRealtimeResourceListResponse<R, E> {
   const contextProps = useContext(WSContext);
 
   if (!contextProps) {
@@ -41,10 +42,10 @@ function useRealtimeResourceList<R extends Identifiable, K extends keyof R>(
     delete config.orderBy;
   }
 
-  const response = useResourceList(listUrl, getResourceUrl, config);
+  const response = useResourceList<R, E>(listUrl, getResourceUrl, config);
   const { mutate } = response;
   const callbackRef = useRef<
-    (update: ResourceBroadcast<R> | RevalidationUpdate) => Promise<R[]>
+    (update: ResourceBroadcast<R> | RevalidationUpdate) => Promise<MutateResponse<R[], E>>
   >();
 
   callbackRef.current = async (
@@ -52,24 +53,29 @@ function useRealtimeResourceList<R extends Identifiable, K extends keyof R>(
   ) => {
     switch (update.action) {
       case Action.CREATED:
-        return mutate(update.instance.id, update.instance, {
+        return mutate(update.instance, {
+          method: "POST",
           sendRequest: false,
           revalidate: false,
-          append: true,
           sortBy: orderBy
-        });
+        })
       case Action.UPDATED:
-        return mutate(update.instance.id, update.instance, {
+        return mutate(update.instance, {
+          method: "PATCH",
+          id: update.instance.id,
           sendRequest: false,
           revalidate: false
         });
       case Action.DELETED:
-        return mutate(update.instance.id, null, {
+        return mutate(null, {
+          method: "DELETE",
+          id: update.instance.id,
           sendRequest: false,
-          revalidate: false
+          revalidate: false,
         });
       case "REVALIDATE":
-        return mutate(undefined, undefined, { sendRequest: false });
+        // what on earth bro
+        return mutate();
     }
   };
 


### PR DESCRIPTION
**Need to update package version still...** Should be handled by something automatic..? will ask Ying

## Major changes

- `useResourceList` supports `PATCH`, `POST`, and `DELETE`
- Instead of passing an `id` both into the new `POST`ed data object and as a parameter of the function, the new method just needs the `id` to exist in the object and the hook will handle it
- Options object is required for `useResourceList` with method defined